### PR TITLE
Feat/map fmap

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -84,6 +84,13 @@ def read_bids_dataset(bids_input, subject_list=None, session_list=None, collect_
 
 
 def set_anatomicals(layout, subject, sessions):
+    """
+    Returns dictionary of anatomical (T1w, T2w) filepaths and associated
+    metadata, and set of types.
+    :param subject: participant label.
+    :param sessions: iterable of session labels.
+    """
+
     types = set()
     t1ws = layout.get(subject=subject, session=sessions, datatype='anat',
                       suffix='T1w', extension=['nii.gz','nii'])
@@ -113,6 +120,12 @@ def set_anatomicals(layout, subject, sessions):
 
 
 def set_functionals(layout, subject, sessions):
+    """
+    Returns dictionary of functional (bold) filepaths and associated metadata,
+    and set of types.
+    :param subject: participant label.
+    :param sessions: iterable of session labels.
+    """
     func = layout.get(subject=subject, session=sessions, datatype='func',
                       suffix='bold', extension=['nii.gz','nii'])
     func_metadata = [layout.get_metadata(x.path) for x in func]
@@ -129,7 +142,8 @@ def set_functionals(layout, subject, sessions):
 def set_fieldmaps(layout, subject, sessions):
     """
     Returns dictionary of fieldmap (epi or magnitude) filepaths and associated
-    metadata. Only fieldmaps with 'IntendedFor' metadata are returned.
+    metadata. Only fieldmaps with 'IntendedFor' metadata are returned. Also
+    returns set of types.
     :param subject: participant label.
     :param sessions: iterable of session labels.
     """
@@ -178,13 +192,9 @@ def set_fieldmaps(layout, subject, sessions):
                     'negative': [fmap_metadata[i] for i in negative]}
 
     else:
-        # The other field map types found above will be filtered out in the
+        # The other field-map types found above will be filtered out in the
         # implementation - see pipelines.py.
         pass
-
-    # DEBUG
-    print ('There are %s entries in fmap.' % len(fmap))
-    print ('There are %s entries in fmap_metadata.' % len(fmap_metadata))
 
     spec = {
         'fmap': fmap,

--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -678,7 +678,7 @@ class Stage(object):
             # This path is used when we are in stages that make a thread for
             # each task. Cap the number of processes as we keep running out of
             # memory when we have too many tasks - KJS 20200303
-            with mp.Pool(processes=4) as pool:
+            with mp.Pool(processes=6) as pool:
                 result = pool.starmap(self.call, cmdlist)
         else:
             cmd = self.cmdline()

--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -675,7 +675,10 @@ class Stage(object):
                 err_log = os.path.join(log_dir,
                                        self.kwargs['fmriname'] + '.err')
                 cmdlist.append((cmd, out_log, err_log))
-            with mp.Pool(processes=ncpus) as pool:
+            # This path is used when we are in stages that make a thread for
+            # each task. Cap the number of processes as we keep running out of
+            # memory when we have too many tasks - KJS 20200303
+            with mp.Pool(processes=4) as pool:
                 result = pool.starmap(self.call, cmdlist)
         else:
             cmd = self.cmdline()


### PR DESCRIPTION
This pipeline has ignored the 'IntendedFor' field in the metadata until now. Now it will only use fmaps that have the field and, will apply the fmaps for distortion correction according to the field. This affects both the PreFreeSurfer and FMRIVolume stages of the pipeline. For the former, the fmaps "intended for" anat (T1w and/or T2w) files are used; for the latter, the fmaps "intended for" the func (bold) files are used