### PR TITLE
Cap the thread-pool used for processing tasks.

### DIFF
--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -678,7 +678,9 @@ class Stage(object):
             # This path is used when we are in stages that make a thread for
             # each task. Cap the number of processes as we keep running out of
             # memory when we have too many tasks - KJS 20200303
-            with mp.Pool(processes=8) as pool:
+            if ncpus > 6:
+                ncpus=6
+            with mp.Pool(processes=ncpus) as pool:
                 result = pool.starmap(self.call, cmdlist)
         else:
             cmd = self.cmdline()

--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -678,7 +678,7 @@ class Stage(object):
             # This path is used when we are in stages that make a thread for
             # each task. Cap the number of processes as we keep running out of
             # memory when we have too many tasks - KJS 20200303
-            with mp.Pool(processes=6) as pool:
+            with mp.Pool(processes=8) as pool:
                 result = pool.starmap(self.call, cmdlist)
         else:
             cmd = self.cmdline()


### PR DESCRIPTION
When we have lots of tasks and try to process them all at the same time, they take too much memory all at one time and some of the threads get shorted of memory and die. So, no matter how many thread we actually have when we start the pipeline, don't try to process more than a few tasks at the same time.