### PR TITLE
Fix for too many threads.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN python3 -m pip install -r "/app/requirements.txt"
 
 # insert pipeline code
 ADD https://github.com/DCAN-Labs/dcan-infant-pipeline.git version.json
-RUN git clone -b 'v0.0.9' --single-branch --depth 1 https://github.com/DCAN-Labs/dcan-infant-pipeline.git /opt/pipeline
+#RUN git clone -b 'v0.0.9' --single-branch --depth 1 https://github.com/DCAN-Labs/dcan-infant-pipeline.git /opt/pipeline
+RUN git clone -b 'master' --single-branch --depth 1 https://github.com/DCAN-Labs/dcan-infant-pipeline.git /opt/pipeline
 
 
 # unless otherwise specified...

--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -1146,7 +1146,7 @@ def _call(cmd, out_log, err_log, num_threads=1):
     if num_threads > 1:
         # set parallel environment variables
         env['OMP_NUM_THREADS'] = str(num_threads)
-        env['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = 1 # str(num_threads)
+        env['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = str(1) # str(num_threads)
         if num_threads != 1:
             print('Keep ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS at 1 instead of %s.' % num_threads)
     with open(out_log, 'w') as out, open(err_log, 'w') as err:

--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -1146,7 +1146,9 @@ def _call(cmd, out_log, err_log, num_threads=1):
     if num_threads > 1:
         # set parallel environment variables
         env['OMP_NUM_THREADS'] = str(num_threads)
-        env['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = str(num_threads)
+        env['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = 1 # str(num_threads)
+        if num_threads != 1:
+            print('Keep ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS at 1 instead of %s.' % num_threads)
     with open(out_log, 'w') as out, open(err_log, 'w') as err:
         result = subprocess.call(cmd.split(), stdout=out, stderr=err, env=env)
         if type(result) is list:

--- a/app/pipelines.py
+++ b/app/pipelines.py
@@ -1146,7 +1146,7 @@ def _call(cmd, out_log, err_log, num_threads=1):
     if num_threads > 1:
         # set parallel environment variables
         env['OMP_NUM_THREADS'] = str(num_threads)
-        env['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = str(1) # str(num_threads)
+        env['ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'] = str(2) # str(num_threads)
         if num_threads != 1:
             print('Keep ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS at 1 instead of %s.' % num_threads)
     with open(out_log, 'w') as out, open(err_log, 'w') as err:


### PR DESCRIPTION
Fix the number of ANTs threads at 2 per ANTs instance. There will still be 10 instances. Scripts should all request 20 cores.