### PR TITLE
Increment internal-tools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:dbp_zero_padding
+FROM dcanumn/internal-tools:v1.0.9
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:v1.0.7
+FROM dcanumn/internal-tools:dbp_zero_padding
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
New internal-tools version contains changes to dcan_bold_proc that include zero padding of timeseries data for proper bandpass filtering.