### PR TITLE
internal-tools update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:R2019a-test
+FROM dcanumn/internal-tools:v1.0.12
 
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dcanumn/internal-tools:v1.0.10
+FROM dcanumn/internal-tools:R2019a-test
 
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/SetupEnv.sh
+++ b/SetupEnv.sh
@@ -38,7 +38,7 @@ export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
 
 # Set up DCAN Environment Variables
 export SCRATCHDIR=/tmp
-export MCRROOT=/opt/mcr/v91
+export MCRROOT=/opt/mcr/v96
 export DCANBOLDPROCDIR=/opt/dcan-tools/dcan_bold_proc
 export DCANBOLDPROCVER=DCANBOLDProc_v4.0.0
 export EXECSUMDIR=/opt/dcan-tools/executivesummary

--- a/app/run.py
+++ b/app/run.py
@@ -24,7 +24,7 @@ NeuroImage, 62:782-90, 2012
 [6] Avants, BB et al. The Insight ToolKit image registration framework. Front
 Neuroinform. 2014 Apr 28;8:44. doi: 10.3389/fninf.2014.00044. eCollection 2014.
 """
-__version__ = "0.0.23"
+__version__ = "0.0.24"
 
 import argparse
 import os


### PR DESCRIPTION
Bump internal-tools version from 1.0.10 -> 1.0.12, addressing two issues:
- Missing outlier .mat files in DCANBOLDProcessing
- Docker build failure due to broken NeuroDocker ANTs link